### PR TITLE
Connect to the REPL if the load' event has fired

### DIFF
--- a/src/figwheel/repl/preload.cljs
+++ b/src/figwheel/repl/preload.cljs
@@ -1,6 +1,6 @@
 (ns figwheel.repl.preload
   (:require [figwheel.repl :as fr]))
 
-(if (= fr/host-env :html)
+(if (and (= fr/host-env :html) (not= (. js/document -readyState) "complete"))
   (.addEventListener goog.global "load" #(fr/connect))
   (fr/connect))


### PR DESCRIPTION
Hey Bruce! I just wanted to say thanks for Figwheel and the guidance for new devs. I'm just ramping up with Clojure and ClojureScript and I've really appreciated the amazing documentation and tooling. 👏

--

**Problem**
We've assumed that the REPL will always be initialized before the `load` even has fired in the browser. That's not always the case, which can be pretty confusing.

I've been trying to set up Figwheel Main with a browser extension. Here's an example showing how the REPL doesn't connect. To show the `document.readystate`, I've changed the compiled output of this file to log it to the console.

|`readyState`|Screenshot|
|-|-|
|`complete` 😞 |![Screen Shot 2019-07-17 at 15 43 13](https://user-images.githubusercontent.com/2585460/61406633-3d6d7100-a8aa-11e9-890c-15adbfb19ff7.png)|
|`interactive`|![Screen Shot 2019-07-17 at 15 56 00](https://user-images.githubusercontent.com/2585460/61407293-67736300-a8ab-11e9-9ba5-cc3f9e6ce490.png)|

<br/>

**Proposed Changes**
We'll have a more reliable connection if we skip the event listener when the `document.readystate` is `complete`. To build confidence in the change:
* here's the event order from the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event) for the `load` event:
    * readystate: interactive
    * DOMContentLoaded
    * readystate: complete
   * load
* Based on [this table](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState#Browser_compatibility), the browser compatibility should not be a concern.

<br/>  

**Testing**
It seems to work better for me. . Notice how the REPL connects when `document.readystate` is `complete`:
![Screen Shot 2019-07-17 at 16 04 10](https://user-images.githubusercontent.com/2585460/61407807-9b02bd00-a8ac-11e9-8f85-f49313d3d977.png)
